### PR TITLE
Fix spelling of key in local Strage to be able to retrieve info

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -20,7 +20,7 @@ class Player {
     if (this.name === 'Human') {
     parsedWin = JSON.parse(localStorage.getItem('humanWins'));
     } else {
-    parsedWin = JSON.parse(localStorage.getItem('compWin'));
+    parsedWin = JSON.parse(localStorage.getItem('compWins'));
     }
     return parsedWin;
   }


### PR DESCRIPTION
Branch Name

- feature/fix-local-storage


Changes Made 

- The key for the computer's wins was missing an "s", and so wasn't able to get the item, because the key I set, and the key I used to receive didn't match, so I added the S, so that they could be retrieved.

Anything refactored?

- No.

Anything else?

- I need to fix my reset timer bug.